### PR TITLE
add ctrl trigger

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,16 @@ module.exports = function(format, progressBarOptions, bindings) {
 
   process.stdin.on('keypress', function (ch, key) {
     if (key) {
-      if (key.ctrl && key.name === 'c') {
-        process.stdin.pause();
+      if (key.ctrl === true) {
+        if (key.name === 'c') {
+          process.stdin.pause();
+        } else if (key.name === 'd') {
+          process.exit();
+        }
+        var binding = bindings['ctrl-' + key.name];
+        if (binding && typeof binding === 'function') {
+          binding();
+        }
       } else if (key.name in bindings && typeof bindings[key.name] === 'function') {
         bindings[key.name]();
       }


### PR DESCRIPTION
@ewnd9, here has the following 2 things that I did in this patch:
- `ctrl-d` should also be handled as a default behavior
- when `key.ctrl` equals `true`, we also should have the ability to run the configured triggers especially for `ctrl-c`, because I met a problem with the following usage:

``` js
progressControl(text, {total: 10}, {
  // something
});
setInterval(function () {
  // do something
}, 1000);
```

Because the function `setInterval` would make the process still be hanged up even though I pressed the `ctrl-c`, and plus, the `process.stdin` has been paused, so I have to force to terminate the process.
